### PR TITLE
Small UI Fixes on Table Pagination Component

### DIFF
--- a/components/shared/table/table-pagination.tsx
+++ b/components/shared/table/table-pagination.tsx
@@ -23,7 +23,6 @@ export const TablePagination = ({
   canPreviousPage,
   canNextPage,
   pageCount,
-  pageOptions,
   pageIndex,
   gotoPage,
   nextPage,
@@ -53,7 +52,7 @@ export const TablePagination = ({
         <span className="mx-2">
           Page{' '}
           <strong>
-            {pageIndex + 1} of {pageOptions.length}
+            {pageIndex + 1} of {pageCount}
           </strong>{' '}
         </span>
         |

--- a/components/shared/table/table-pagination.tsx
+++ b/components/shared/table/table-pagination.tsx
@@ -76,7 +76,7 @@ export const TablePagination = ({
       </div>
       <div className="">
         <select
-          className="tag tag-smoke text-xl"
+          className="tag tag-smoke min-w-[90px] bg-white text-xl text-neutral-700 dark:bg-neutral-800 dark:text-neutral-100"
           value={pageSize}
           onChange={(e) => {
             setPageSize(Number(e.target.value))

--- a/components/shared/table/table-pagination.tsx
+++ b/components/shared/table/table-pagination.tsx
@@ -62,6 +62,8 @@ export const TablePagination = ({
             <input
               className="input ml-3 h-[32px] w-[64px] text-neutral-700 dark:text-neutral-800"
               type="number"
+              min={1}
+              max={pageCount}
               defaultValue={pageIndex + 1}
               onChange={(e) => {
                 const page = e.target.value ? Number(e.target.value) - 1 : 0


### PR DESCRIPTION
**Description:**
This pull request addresses a few minor UI issues related to the pagination of the table component. The changes include:

[**1. Refactor:**](https://github.com/turbo-eth/template-web3-app/commit/6f2f03eb38dd83930d606da67dd0811278571cd8) Replaced `pageOptions.length` with the already used `pageCount` prop. This change streamlines the code by utilizing the already used prop to get the total number of pages.

[**2. Bugfix:**](https://github.com/turbo-eth/template-web3-app/commit/0cbf35abe5e85bea9a6c606babad90da17b38400) The 'go to page' input now has bounds to prevent users from entering values less than 1 or greater than `pageCount`. This ensures that only valid page indexes can be entered.
> Screenshots from https://www.turboeth.xyz/integration/etherscan.
![image](https://user-images.githubusercontent.com/18421017/230639531-269a05cd-6c27-4fdf-b2ed-8e3c3a8c200e.png)
![image](https://user-images.githubusercontent.com/18421017/230639582-be26f856-7e40-4266-8d39-59f0ca3b0757.png)

[**3. Bugfix:**](https://github.com/turbo-eth/template-web3-app/commit/14213acb327de0934f55474d331e8569aa9ac59e) Fixed the overlap issue between the content of the 'show pages' select and its arrow by setting a minimum width for the component. Additionally, the text color of the component in dark mode has been adjusted to improve readability with the white background.
> Screenshots from https://www.turboeth.xyz/integration/etherscan.
![image](https://user-images.githubusercontent.com/18421017/230639650-6ee44294-b97a-4155-90ff-ab0f768b0fbd.png)
![image](https://user-images.githubusercontent.com/18421017/230639922-e883f51e-bbed-4b6a-b7b8-2ade96f9f87b.png)

> Screenshots from local development with the fixes below
![image](https://user-images.githubusercontent.com/18421017/230639994-0a91f29b-4a0e-487d-9f9d-db69dc58035e.png)
![image](https://user-images.githubusercontent.com/18421017/230640059-ad25167b-675c-4b01-8a6a-e6530886f306.png)








