### PR TITLE
Refactor: Separate SIWE message functionality from siweLogin function

### DIFF
--- a/integrations/siwe/actions/siwe-login.ts
+++ b/integrations/siwe/actions/siwe-login.ts
@@ -1,29 +1,10 @@
-import { SiweMessage } from 'siwe'
-
-import { siteConfig } from '@/config/site'
+import { siweMessage } from './siwe-message'
 
 export const siweLogin = async ({ address, chainId, signMessageAsync }: any) => {
-  // 1. Get random nonce from API
-  const nonceRes = await fetch('/api/siwe/nonce')
-  const nonce = await nonceRes.text()
+  // 1. Create and sign SIWE message
+  const { message, signature } = await siweMessage({ address, chainId, signMessageAsync })
 
-  // 2. Create SIWE message with pre-fetched nonce and sign with wallet
-  const message = new SiweMessage({
-    domain: window.location.host,
-    address,
-    statement: `Sign in with Ethereum to ${siteConfig.name}`,
-    uri: window.location.origin,
-    version: '1',
-    chainId: chainId,
-    nonce: nonce,
-  })
-
-  // 3. Sign message
-  const signature = await signMessageAsync({
-    message: message.prepareMessage(),
-  })
-
-  // 3. Verify signature
+  // 2. Verify signature
   const verifyRes = await fetch('/api/siwe/verify', {
     method: 'POST',
     headers: {

--- a/integrations/siwe/actions/siwe-message.ts
+++ b/integrations/siwe/actions/siwe-message.ts
@@ -1,0 +1,44 @@
+import { SiweMessage } from 'siwe'
+import { SignMessageArgs } from 'wagmi/dist/actions'
+
+import { siteConfig } from '@/config/site'
+
+interface SiweMessageOptions {
+  address: string
+  chainId: number
+  signMessageAsync: (args?: SignMessageArgs | undefined) => Promise<`0x${string}`>
+}
+
+/**
+ * Utility function to create and sign a SIWE message
+ * @param address - Ethereum address
+ * @param chainId - Ethereum chain ID
+ * @param signMessageAsync - Wallet sign message function
+ * @returns SIWE message and signature
+ */
+export const siweMessage = async ({ address, chainId, signMessageAsync }: SiweMessageOptions) => {
+  // 1. Get random nonce from API
+  const nonceRes = await fetch('/api/siwe/nonce')
+  const nonce = await nonceRes.text()
+
+  // 2. Create SIWE message with pre-fetched nonce and sign with wallet
+  const message = new SiweMessage({
+    domain: window.location.host,
+    address,
+    statement: `Sign in with Ethereum to ${siteConfig.name}`,
+    uri: window.location.origin,
+    version: '1',
+    chainId: chainId,
+    nonce: nonce,
+  })
+
+  // 3. Sign message
+  const signature = await signMessageAsync({
+    message: message.prepareMessage(),
+  })
+
+  return {
+    message,
+    signature,
+  }
+}


### PR DESCRIPTION
**Description:**

In this Pull Request, the SIWE message formatting and signing have been separated from the `siweLogin` function and moved to a new `siweMessage` function. The `siweLogin` function now imports and runs the `siweMessage` function, retaining its original functionality.

This modularization of the `siweMessage` function allows other integrations to use SIWE authentication without requiring the login and logout functions. For example, the upcoming Lit Protocol integration can make use of this functionality.

**Changes:**
- Added a new `siweMessage` function to handle SIWE message creation and signing.
- Updated the `siweLogin` function to use the `siweMessage` function.
- Improved the type of the `signMessageAsync `function argument in the `SiweMessageOptions` interface.
