### PR TITLE
Chore: (main) Enforce ESLint no-unused-imports-ts rule and fix existing unused imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,6 +31,7 @@
         "@typescript-eslint/consistent-type-imports": "off", // Ensure `import type` is used when it's necessary
         "import/prefer-default-export": "off", // Named export is easier to refactor automatically
         "unused-imports/no-unused-vars": "off",
+        "unused-imports/no-unused-imports-ts": "error",
         "tailwindcss/classnames-order": [
           "warn",
           {

--- a/components/app/app-users-table.tsx
+++ b/components/app/app-users-table.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import { Address } from '@turbo-eth/core-wagmi'
-import Link from 'next/link'
 
 import TableCore from '../shared/table/table-core'
 import { TimeFromUtc } from '../shared/time-from-utc'

--- a/components/layout/user-dropdown.tsx
+++ b/components/layout/user-dropdown.tsx
@@ -1,13 +1,13 @@
 import { motion } from 'framer-motion'
-import { BinaryIcon, DatabaseIcon, LayoutDashboard, LogOutIcon, Wallet } from 'lucide-react'
+import { BinaryIcon, DatabaseIcon, LayoutDashboard, LogOutIcon } from 'lucide-react'
 import Link from 'next/link'
 
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { FADE_IN_ANIMATION_SETTINGS } from '@/config/design'
 
+import { BranchIsAuthenticated } from '../../integrations/siwe/components/branch-is-authenticated'
 import { ButtonSIWELogin } from '../../integrations/siwe/components/button-siwe-login'
 import { ButtonSIWELogout } from '../../integrations/siwe/components/button-siwe-logout'
-import { BranchIsAuthenticated } from '../../integrations/siwe/components/branch-is-authenticated'
 
 export function UserDropdown() {
   return (

--- a/components/shared/link-component.tsx
+++ b/components/shared/link-component.tsx
@@ -4,7 +4,6 @@ import React, { ReactNode } from 'react'
 import classNames from 'clsx'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { useRouter } from 'next/router'
 
 interface LinkComponentProps {
   href: string


### PR DESCRIPTION
This Pull Request addresses the issue of unused imports in the codebase by enabling the ESLint rule `no-unused-imports-ts` to throw an error when unused imports are detected. This PR also includes fixes for any existing unused imports in the codebase.