### PR TITLE
[Main] Chore: Replace Axios with Native Fetch Library for Next 13 Compatibility

### DIFF
--- a/integrations/siwe/actions/siwe-logout.ts
+++ b/integrations/siwe/actions/siwe-logout.ts
@@ -1,11 +1,10 @@
-import axios, { AxiosError } from 'axios'
-
 export async function siweLogout(): Promise<boolean> {
   try {
-    await axios.get('/api/siwe/logout')
+    const response = await fetch('/api/siwe/logout')
+    if (!response?.ok) throw new Error(response?.statusText)
     return true
-  } catch (error: any) {
-    if (error instanceof AxiosError == true) {
+  } catch (error: unknown) {
+    if (error instanceof Error == true) {
       return false
     }
     throw new Error(`Unexpected Error`)

--- a/lib/app/get-app-users.ts
+++ b/lib/app/get-app-users.ts
@@ -1,5 +1,3 @@
-import axios from 'axios'
-
 export async function getAppUsers(): Promise<
   | {
       users?: Array<any>
@@ -8,7 +6,10 @@ export async function getAppUsers(): Promise<
   | void
 > {
   try {
-    const { data } = await axios.get('/api/app/users')
+    const response = await fetch('/api/app/users')
+    if (!response?.ok) throw new Error(response?.statusText)
+
+    const data = await response.json()
     return data
   } catch (error: any) {
     throw error

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "@vercel/og": "^0.0.27",
     "@wagmi/chains": "^0.2.13",
     "@wagmi/cli": "^0.1.11",
-    "axios": "^1.2.2",
     "class-variance-authority": "^0.4.0",
     "classnames": "^2.3.2",
     "clsx": "^1.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,6 @@ specifiers:
   '@wagmi/chains': ^0.2.13
   '@wagmi/cli': ^0.1.11
   autoprefixer: ^10.4.13
-  axios: ^1.2.2
   class-variance-authority: ^0.4.0
   classnames: ^2.3.2
   clsx: ^1.2.1
@@ -161,7 +160,6 @@ dependencies:
   '@vercel/og': 0.0.27
   '@wagmi/chains': 0.2.13_typescript@4.9.4
   '@wagmi/cli': 0.1.11_72vdbhswucp6i3hbmtt2vr7aji
-  axios: 1.3.4
   class-variance-authority: 0.4.0_typescript@4.9.4
   classnames: 2.3.2
   clsx: 1.2.1
@@ -6901,10 +6899,6 @@ packages:
     resolution: {integrity: sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==}
     dev: false
 
-  /asynckit/0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-    dev: false
-
   /atob/2.1.2:
     resolution: {integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==}
     engines: {node: '>= 4.5.0'}
@@ -6945,16 +6939,6 @@ packages:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
       follow-redirects: 1.15.2
-    transitivePeerDependencies:
-      - debug
-    dev: false
-
-  /axios/1.3.4:
-    resolution: {integrity: sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==}
-    dependencies:
-      follow-redirects: 1.15.2
-      form-data: 4.0.0
-      proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
     dev: false
@@ -7630,13 +7614,6 @@ packages:
   /colorette/2.0.19:
     resolution: {integrity: sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==}
 
-  /combined-stream/1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
-    dependencies:
-      delayed-stream: 1.0.0
-    dev: false
-
   /comma-separated-tokens/2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
     dev: false
@@ -8122,11 +8099,6 @@ packages:
   /delay/5.0.0:
     resolution: {integrity: sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==}
     engines: {node: '>=10'}
-    dev: false
-
-  /delayed-stream/1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
     dev: false
 
   /denodeify/1.2.1:
@@ -9669,15 +9641,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /form-data/4.0.0:
-    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
-    engines: {node: '>= 6'}
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      mime-types: 2.1.35
-    dev: false
-
   /formdata-polyfill/4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
@@ -9951,7 +9914,6 @@ packages:
 
   /graceful-fs/4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-    dev: true
 
   /grapheme-splitter/1.0.4:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
@@ -10957,7 +10919,7 @@ packages:
   /jsonfile/4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
     optionalDependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
     dev: false
 
   /jsonfile/6.1.0:
@@ -10965,7 +10927,7 @@ packages:
     dependencies:
       universalify: 2.0.0
     optionalDependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
 
   /jsonparse/1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
@@ -13212,10 +13174,6 @@ packages:
 
   /proxy-compare/2.5.0:
     resolution: {integrity: sha512-f1us0OsVAJ3tdIMXGQx2lmseYS4YXe4W+sKF5g5ww/jV+5ogMadPt+sIZ+88Ga9kvMJsrRNWzCrKPpr6pMWYbA==}
-    dev: false
-
-  /proxy-from-env/1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
     dev: false
 
   /pump/3.0.0:


### PR DESCRIPTION
This PR attempts to solve #32 by replacing the axios library with the native fetch API in order to fully utilize the capabilities of Next 13 and server components. As [Next 13 is extending the fetch Web API](https://beta.nextjs.org/docs/data-fetching/fetching) for server-side data fetching, it's essential to transition to the fetch API for better compatibility and performance.

While the main downside of not using axios is that we need to manually convert the response to JSON and fetch only throws errors for network requests, not HTTP errors, these issues are relatively simple to solve. This change allows TurboETH to take full advantage of the improvements offered by Next 13 and server components, leading to a more efficient and streamlined codebase.

**changes:**
- **[Replace Axios with Fetch](https://github.com/turbo-eth/template-web3-app/commit/3f719ab0e49f3ec4a34bbbf55a2d09d4e36ef332)**: Updated the `siweLogout` and `getAppUsers` helper functions to use the native fetch library instead of Axios.
- **[Remove Axios](https://github.com/turbo-eth/template-web3-app/commit/40a42476c89bcc2f76844bcbaf7d5cbab13ddc61)**: Removed the Axios package from the repository.


