### PR TITLE
[main] Chore: add support to polygon mumbai and celo networks

### DIFF
--- a/config/networks.ts
+++ b/config/networks.ts
@@ -1,7 +1,21 @@
 // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 // Networks
 // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-import { arbitrum, arbitrumGoerli, baseGoerli, goerli, hardhat, mainnet, optimism, optimismGoerli, polygon, sepolia } from '@wagmi/chains'
+import {
+  arbitrum,
+  arbitrumGoerli,
+  baseGoerli,
+  celo,
+  celoAlfajores,
+  goerli,
+  hardhat,
+  mainnet,
+  optimism,
+  optimismGoerli,
+  polygon,
+  polygonMumbai,
+  sepolia,
+} from '@wagmi/chains'
 import { configureChains } from 'wagmi'
 import { alchemyProvider } from 'wagmi/providers/alchemy'
 import { infuraProvider } from 'wagmi/providers/infura'
@@ -15,10 +29,27 @@ sepolia.iconUrl = '/icons/NetworkEthereumTest.svg'
 arbitrumGoerli.iconUrl = '/icons/NetworkArbitrumTest.svg'
 // @ts-ignore
 baseGoerli.iconUrl = '/icons/NetworkBaseTest.svg'
+// @ts-ignore
+celo.iconUrl = '/icons/NetworkCelo.svg'
+// @ts-ignore
+celoAlfajores.iconUrl = '/icons/NetworkCeloTest.svg'
 
 const CHAINS_SUPPORTED_BY_ALCHEMY = [mainnet, goerli, sepolia] // TODO add other chains supported by Alchemy
 const CHAINS_SUPPORTED_BY_INFURA = [mainnet, goerli, sepolia] // TODO add other chains supported by Infura
-const CHAINS_SUPPORTED_BY_PUBLIC_PROVIER = [arbitrum, arbitrumGoerli, baseGoerli, goerli, mainnet, optimism, optimismGoerli, polygon, sepolia]
+const CHAINS_SUPPORTED_BY_PUBLIC_PROVIER = [
+  arbitrum,
+  arbitrumGoerli,
+  baseGoerli,
+  goerli,
+  mainnet,
+  optimism,
+  optimismGoerli,
+  polygon,
+  polygonMumbai,
+  celo,
+  celoAlfajores,
+  sepolia,
+]
 const CHAINS_SUPPORTED_BY_HARDHAT = [hardhat]
 
 const PROVIDERS = []

--- a/public/icons/NetworkCelo.svg
+++ b/public/icons/NetworkCelo.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 250 250" style="enable-background:new 0 0 250 250;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FCFF52;}
+</style>
+<circle class="st0" cx="125" cy="125" r="125"/>
+<path d="M188.9,60.7H60.7v128.2h128.2v-44.8h-21.3c-7.3,16.3-23.8,27.7-42.7,27.7c-26,0-47.1-21.3-47.1-47.1c0-25.9,21.1-47,47.1-47
+	c19.3,0,35.8,11.7,43.1,28.4h20.9V60.7z"/>
+</svg>

--- a/public/icons/NetworkCeloTest.svg
+++ b/public/icons/NetworkCeloTest.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 250 250" style="enable-background:new 0 0 250 120;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#476520;}
+</style>
+<circle class="st0" cx="125" cy="125" r="125"/>
+<path fill="#FCF6F1" d="M188.9,60.7H60.7v128.2h128.2v-44.8h-21.3c-7.3,16.3-23.8,27.7-42.7,27.7c-26,0-47.1-21.3-47.1-47.1c0-25.9,21.1-47,47.1-47
+	c19.3,0,35.8,11.7,43.1,28.4h20.9V60.7z"/>
+</svg>


### PR DESCRIPTION
This PR adds support for the Polygon testnet mumbai, since the Polygon mainnet was already supported. It also adds support for Celo mainnet and its testnet, Alfajores. Since Rainbowkit doesn't support Celo icons, new ones were added from the [Celo rainbowkit example](https://rainbowkit-with-celo.vercel.app/icons/celo.svg)