### PR TITLE
[main] Refactor: move og and twitter image to route based convention

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,7 +4,6 @@ import '@/styles/periphery.css'
 import { Raleway } from '@next/font/google'
 import { Inter as FontSans } from '@next/font/google'
 import localFont from '@next/font/local'
-import { Metadata } from 'next'
 
 import RootProvider from '@/components/providers/root-provider'
 import { siteConfig } from '@/config/site'
@@ -12,9 +11,8 @@ import { env } from '@/env.mjs'
 import { cn } from '@/lib/utils'
 
 const url = env.SITE_URL || 'http://localhost:3000'
-const ogUrl = new URL(`${url}/api/og`)
 
-export const metadata: Metadata = {
+export const metadata = {
   title: `${siteConfig.name} - ${siteConfig.description}`,
   description: siteConfig.description,
   icons: {
@@ -24,7 +22,6 @@ export const metadata: Metadata = {
     title: siteConfig.name,
     description: siteConfig.description,
     url: url?.toString(),
-    images: [ogUrl.toString()],
     siteName: siteConfig.name,
     type: 'website',
   },
@@ -32,7 +29,6 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title: siteConfig.name,
     description: siteConfig.description,
-    images: [ogUrl.toString()],
   },
 }
 

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,20 +1,20 @@
-/* eslint-disable @next/next/no-img-element */
-import { ImageResponse } from '@vercel/og'
-import { NextRequest } from 'next/server'
+import { ImageResponse } from 'next/server'
 
 import { siteConfig } from '@/config/site'
 
-export const config = {
-  runtime: 'experimental-edge',
+export const runtime = 'edge'
+
+export const alt = 'TurboETH Logo'
+export const size = {
+  width: 1200,
+  height: 630,
 }
 
-const sfPro = fetch(new URL('../../assets/fonts/SF-Pro-Display-Medium.otf', import.meta.url)).then((res) => res.arrayBuffer())
+export const contentType = 'image/png'
 
-export default async function handler(req: NextRequest) {
-  const [sfProData] = await Promise.all([sfPro])
+const sfPro = fetch(new URL('../assets/fonts/SF-Pro-Display-Medium.otf', import.meta.url)).then((res) => res.arrayBuffer())
 
-  const { searchParams } = req.nextUrl
-  const title = searchParams.get('title') || siteConfig.name
+export default async function Image() {
   return new ImageResponse(
     (
       <div
@@ -28,7 +28,7 @@ export default async function handler(req: NextRequest) {
           backgroundColor: 'white',
           backgroundImage: 'linear-gradient(to bottom right, #FFF 25%, #FFF0CA 75%)',
         }}>
-        <img src={new URL('../../public/logo-fill.png', import.meta.url).toString()} alt="TurboETH Logo" tw="w-20 h-20 mb-4 opacity-95" />
+        <img src={new URL('../public/logo-fill.png', import.meta.url).toString()} alt="TurboETH Logo" tw="w-20 h-20 mb-4 opacity-95" />
         <h1
           style={{
             fontSize: '100px',
@@ -57,12 +57,10 @@ export default async function handler(req: NextRequest) {
       </div>
     ),
     {
-      width: 1200,
-      height: 630,
       fonts: [
         {
           name: 'SF Pro',
-          data: sfProData,
+          data: await sfPro,
         },
       ],
     }

--- a/app/twitter-image.tsx
+++ b/app/twitter-image.tsx
@@ -1,0 +1,13 @@
+import Image from './opengraph-image'
+
+export const runtime = 'edge'
+
+export const alt = 'TurboETH Logo'
+export const size = {
+  width: 1200,
+  height: 630,
+}
+
+export const contentType = 'image/png'
+
+export default Image

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "@turbo-eth/erc721-wagmi": "0.0.0-beta.7",
     "@types/react-copy-to-clipboard": "^5.0.4",
     "@vercel/analytics": "^0.1.6",
-    "@vercel/og": "^0.0.27",
     "@wagmi/chains": "^0.2.13",
     "@wagmi/cli": "^0.1.11",
     "class-variance-authority": "^0.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,9 +127,6 @@ dependencies:
   '@vercel/analytics':
     specifier: ^0.1.6
     version: 0.1.11(react@18.2.0)
-  '@vercel/og':
-    specifier: ^0.0.27
-    version: 0.0.27
   '@wagmi/chains':
     specifier: ^0.2.13
     version: 0.2.13(typescript@4.9.4)
@@ -5353,11 +5350,6 @@ packages:
       zustand: 3.7.2(react@18.2.0)
     dev: false
 
-  /@resvg/resvg-wasm@2.0.0-alpha.4:
-    resolution: {integrity: sha512-pWIG9a/x1ky8gXKRhPH1OPKpHFoMN1ISLbJ+O+gPXQHIAKhNd5I28RlWf7q576hAOQA9JZTlo3p/M2uyLzJmmw==}
-    engines: {node: '>= 10'}
-    dev: false
-
   /@rushstack/eslint-patch@1.2.0:
     resolution: {integrity: sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==}
     dev: true
@@ -5401,15 +5393,6 @@ packages:
       cross-fetch: 3.1.5(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
-    dev: false
-
-  /@shuding/opentype.js@1.4.0-beta.0:
-    resolution: {integrity: sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==}
-    engines: {node: '>= 8.0.0'}
-    hasBin: true
-    dependencies:
-      fflate: 0.7.4
-      string.prototype.codepointat: 0.2.1
     dev: false
 
   /@sideway/address@4.1.4:
@@ -6416,15 +6399,6 @@ packages:
       react: ^16.8||^17||^18
     dependencies:
       react: 18.2.0
-    dev: false
-
-  /@vercel/og@0.0.27:
-    resolution: {integrity: sha512-cUk6HmfLmBOISAA8gvPRNUx3eVOSyXblxiuv3uN9UTxLwdalQzPlHC/0byvTMR1eVi0y1trD5u6um/4xiTqgOQ==}
-    engines: {node: '>=16'}
-    dependencies:
-      '@resvg/resvg-wasm': 2.0.0-alpha.4
-      satori: 0.0.46
-      yoga-wasm-web: 0.3.0
     dev: false
 
   /@wagmi/chains@0.2.13(typescript@4.9.4):
@@ -7831,10 +7805,6 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  /camelize@1.0.1:
-    resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
-    dev: false
-
   /caniuse-lite@1.0.30001464:
     resolution: {integrity: sha512-oww27MtUmusatpRpCGSOneQk2/l5czXANDSFvsc7VuOQ86s3ANhZetpwXNf1zY/zdfP63Xvjz325DAdAoES13g==}
     dev: true
@@ -8296,19 +8266,6 @@ packages:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  /css-background-parser@0.1.0:
-    resolution: {integrity: sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==}
-    dev: false
-
-  /css-box-shadow@1.0.0-3:
-    resolution: {integrity: sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==}
-    dev: false
-
-  /css-color-keywords@1.0.0:
-    resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
-    engines: {node: '>=4'}
-    dev: false
-
   /css-mediaquery@0.1.2:
     resolution: {integrity: sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==}
     dev: false
@@ -8322,14 +8279,6 @@ packages:
       domutils: 2.8.0
       nth-check: 2.1.1
     dev: true
-
-  /css-to-react-native@3.2.0:
-    resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
-    dependencies:
-      camelize: 1.0.1
-      css-color-keywords: 1.0.0
-      postcss-value-parser: 4.2.0
-    dev: false
 
   /css-tree@1.1.3:
     resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
@@ -8766,10 +8715,6 @@ packages:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
-    dev: false
-
-  /emoji-regex@10.2.1:
-    resolution: {integrity: sha512-97g6QgOk8zlDRdgq1WxwgTMgEWGVAQvB5Fdpgc1MkNy56la5SKP9GsMXKDOdqwn90/41a8yPwIGk1Y6WVbeMQA==}
     dev: false
 
   /emoji-regex@8.0.0:
@@ -9918,10 +9863,6 @@ packages:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.2.1
-    dev: false
-
-  /fflate@0.7.4:
-    resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
     dev: false
 
   /file-entry-cache@6.0.1:
@@ -14509,19 +14450,6 @@ packages:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
     dev: false
 
-  /satori@0.0.46:
-    resolution: {integrity: sha512-7RfTz38MB0n8tzmRHtUh1y0K7609CLBHpYuyZuh9rpf9FyhOd2in+6EHuqu6ul/Jebn1qD1HdYKtAMjb7uiNAQ==}
-    engines: {node: '>=16'}
-    dependencies:
-      '@shuding/opentype.js': 1.4.0-beta.0
-      css-background-parser: 0.1.0
-      css-box-shadow: 1.0.0-3
-      css-to-react-native: 3.2.0
-      emoji-regex: 10.2.1
-      postcss-value-parser: 4.2.0
-      yoga-wasm-web: 0.3.0
-    dev: false
-
   /scheduler@0.13.3:
     resolution: {integrity: sha512-UxN5QRYWtpR1egNWzJcVLk8jlegxAugswQc984lD3kU7NuobsO37/sRfbpTdBjtnD5TBNFA2Q2oLV5+UmPSmEQ==}
     dependencies:
@@ -15010,10 +14938,6 @@ packages:
       emoji-regex: 9.2.2
       strip-ansi: 7.0.1
     dev: true
-
-  /string.prototype.codepointat@0.2.1:
-    resolution: {integrity: sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==}
-    dev: false
 
   /string.prototype.matchall@4.0.8:
     resolution: {integrity: sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==}
@@ -16203,10 +16127,6 @@ packages:
   /yocto-queue@1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
-    dev: false
-
-  /yoga-wasm-web@0.3.0:
-    resolution: {integrity: sha512-rD3L4jyMlO1m+RWU60lNwZQK5zmzglCV5fI1gTRikmpv3YzmNIZQbjyfE6cMNb9Xaly/C1SwemYGbsiOekMvnQ==}
     dev: false
 
   /zdog@1.1.3:


### PR DESCRIPTION
This PR moves the OpenGraph and Twitter images from using the `/api/og` endpoint and [Metadata API](https://nextjs.org/docs/app/building-your-application/optimizing/metadata) to using the new [Nextjs metadata files](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/opengraph-image).