### PR TITLE
[integrations] Fix: split client and server code

### DIFF
--- a/integrations/disco/hooks/use-disco-get-credentials-from-did.ts
+++ b/integrations/disco/hooks/use-disco-get-credentials-from-did.ts
@@ -1,7 +1,7 @@
 import { useQuery } from 'wagmi'
 
-import { discoGetCredentialsFromDID } from '@/integrations/disco/routes/get-credentials-from-did'
+import { appDiscoGetCredentialsFromDID } from '@/integrations/disco/routes/get-credentials-from-did/client'
 
 export const useDiscoGetCredentialsFromDID = (did?: string, queryKey?: any) => {
-  return useQuery(['discoCredentialsFromDID', did, queryKey], () => discoGetCredentialsFromDID(did))
+  return useQuery(['discoCredentialsFromDID', did, queryKey], () => appDiscoGetCredentialsFromDID(did))
 }

--- a/integrations/disco/hooks/use-disco-get-profile-from-address.ts
+++ b/integrations/disco/hooks/use-disco-get-profile-from-address.ts
@@ -1,7 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
-import error from 'next/error'
 
-import { appDiscoGetProfileFromAddress } from '@/integrations/disco/routes/get-profile-from-address'
+import { appDiscoGetProfileFromAddress } from '@/integrations/disco/routes/get-profile-from-address/client'
 
 export const useDiscoGetProfileFromAddress = (address?: `0x${string}`, queryKey?: any) => {
   return useQuery(['discoProfileFromAddress', address, queryKey], async () => appDiscoGetProfileFromAddress(address))

--- a/integrations/disco/hooks/use-disco-get-profile-from-did.ts
+++ b/integrations/disco/hooks/use-disco-get-profile-from-did.ts
@@ -1,7 +1,7 @@
 import { useQuery } from 'wagmi'
 
-import { discoGetCredentialsFromDID } from '@/integrations/disco/routes/get-credentials-from-did'
+import { appDiscoGetCredentialsFromDID } from '@/integrations/disco/routes/get-credentials-from-did/client'
 
 export const useDiscoGetProfileFromDID = (did?: string, queryKey?: any) => {
-  return useQuery(['discoProfileFromDID', did, queryKey], () => discoGetCredentialsFromDID(did))
+  return useQuery(['discoProfileFromDID', did, queryKey], () => appDiscoGetCredentialsFromDID(did))
 }

--- a/integrations/disco/routes/get-credentials-from-did/client.ts
+++ b/integrations/disco/routes/get-credentials-from-did/client.ts
@@ -1,15 +1,5 @@
 import axios from 'axios'
 
-import { discoClient } from '@/integrations/disco/disco-client'
-
-export async function discoGetCredentialsFromDID(did?: string): Promise<any> {
-  if (!did) {
-    return null
-  }
-  const { data } = await discoClient.get(`/profile/${did}/credentials`)
-  return data
-}
-
 export async function appDiscoGetCredentialsFromDID(did?: string): Promise<any> {
   try {
     const { data } = await axios.get(`/api/disco/profile-from-address`, {

--- a/integrations/disco/routes/get-credentials-from-did/index.ts
+++ b/integrations/disco/routes/get-credentials-from-did/index.ts
@@ -1,0 +1,9 @@
+import { discoClient } from '@/integrations/disco/disco-client'
+
+export async function discoGetCredentialsFromDID(did?: string): Promise<any> {
+  if (!did) {
+    return null
+  }
+  const { data } = await discoClient.get(`/profile/${did}/credentials`)
+  return data
+}

--- a/integrations/disco/routes/get-profile-from-address-simple/client.ts
+++ b/integrations/disco/routes/get-profile-from-address-simple/client.ts
@@ -1,13 +1,3 @@
-import { discoClient } from '@/integrations/disco/disco-client'
-
-export async function discoGetProfileFromAddress(address?: string): Promise<any> {
-  if (!address) {
-    return null
-  }
-  const { data } = await discoClient.get(`/profile/address/${address}`)
-  return data
-}
-
 export async function appDiscoGetProfileFromAddress(address?: `0x${string}`): Promise<any> {
   try {
     const res = await fetch(

--- a/integrations/disco/routes/get-profile-from-address-simple/index.ts
+++ b/integrations/disco/routes/get-profile-from-address-simple/index.ts
@@ -1,0 +1,9 @@
+import { discoClient } from '@/integrations/disco/disco-client'
+
+export async function discoGetProfileFromAddress(address?: string): Promise<any> {
+  if (!address) {
+    return null
+  }
+  const { data } = await discoClient.get(`/profile/address/${address}`)
+  return data
+}

--- a/integrations/disco/routes/get-profile-from-address/client.ts
+++ b/integrations/disco/routes/get-profile-from-address/client.ts
@@ -1,0 +1,14 @@
+import axios from 'axios'
+
+export async function appDiscoGetProfileFromAddress(address?: `0x${string}`): Promise<any> {
+  try {
+    const { data } = await axios.get(`/api/disco/profile-from-address`, {
+      params: {
+        address: address,
+      },
+    })
+    return data
+  } catch (error: any) {
+    throw error
+  }
+}

--- a/integrations/disco/routes/get-profile-from-address/index.ts
+++ b/integrations/disco/routes/get-profile-from-address/index.ts
@@ -1,5 +1,3 @@
-import axios from 'axios'
-
 import { discoClient } from '@/integrations/disco/disco-client'
 
 export async function discoGetProfileFromAddress(address?: string): Promise<any> {
@@ -8,19 +6,6 @@ export async function discoGetProfileFromAddress(address?: string): Promise<any>
       return null
     }
     const { data } = await discoClient.get(`/profile/address/${address}`)
-    return data
-  } catch (error: any) {
-    throw error
-  }
-}
-
-export async function appDiscoGetProfileFromAddress(address?: `0x${string}`): Promise<any> {
-  try {
-    const { data } = await axios.get(`/api/disco/profile-from-address`, {
-      params: {
-        address: address,
-      },
-    })
     return data
   } catch (error: any) {
     throw error

--- a/integrations/disco/routes/get-profile-from-did/client.ts
+++ b/integrations/disco/routes/get-profile-from-did/client.ts
@@ -1,12 +1,5 @@
 import axios from 'axios'
 
-import { discoClient } from '@/integrations/disco/disco-client'
-
-export async function discoGetProfileFromDID(did: string): Promise<any> {
-  const { data } = await discoClient.get(`/profile/${did}`)
-  return data
-}
-
 export async function appDiscoGetProfileFromDID(address?: `0x${string}`): Promise<any> {
   try {
     const { data } = await axios.get(`/api/disco/profile-from-address`, {

--- a/integrations/disco/routes/get-profile-from-did/index.ts
+++ b/integrations/disco/routes/get-profile-from-did/index.ts
@@ -1,0 +1,6 @@
+import { discoClient } from '@/integrations/disco/disco-client'
+
+export async function discoGetProfileFromDID(did: string): Promise<any> {
+  const { data } = await discoClient.get(`/profile/${did}`)
+  return data
+}

--- a/integrations/etherscan/actions/etherscan-account-transactions/client.ts
+++ b/integrations/etherscan/actions/etherscan-account-transactions/client.ts
@@ -1,0 +1,19 @@
+import axios from 'axios'
+
+export async function appEtherscanAccountTransactions(params?: BlockPagination): Promise<
+  | {
+      address: string
+      transactions: Array<any>
+    }
+  | undefined
+  | void
+> {
+  try {
+    const { data } = await axios.get('/api/etherscan/account/transactions', {
+      params: params,
+    })
+    return data
+  } catch (error: any) {
+    throw new Error(`Unexpected Error`)
+  }
+}

--- a/integrations/etherscan/actions/etherscan-account-transactions/index.ts
+++ b/integrations/etherscan/actions/etherscan-account-transactions/index.ts
@@ -1,11 +1,9 @@
-import axios from 'axios'
-
-import getChainIdApiKey from '../utils/get-chain-id-api-key'
-import getEtherscanClient from '../utils/get-etherscan-client'
-import handleErrorTypes from '../utils/handle-error-types'
-import handleEtherscanResponse from '../utils/handle-etherscan-response'
-import isClientConnected from '../utils/is-client-connected'
-import isValidAddress from '../utils/is-valid-address'
+import getChainIdApiKey from '../../utils/get-chain-id-api-key'
+import getEtherscanClient from '../../utils/get-etherscan-client'
+import handleErrorTypes from '../../utils/handle-error-types'
+import handleEtherscanResponse from '../../utils/handle-etherscan-response'
+import isClientConnected from '../../utils/is-client-connected'
+import isValidAddress from '../../utils/is-valid-address'
 
 export async function etherscanAccountTransactions(chainId: number | string, address: string, config: BlockPagination) {
   const client = getEtherscanClient(Number(chainId), 5000, getChainIdApiKey(chainId))
@@ -29,23 +27,5 @@ export async function etherscanAccountTransactions(chainId: number | string, add
     return handleEtherscanResponse(data)
   } catch (error) {
     return handleErrorTypes(error)
-  }
-}
-
-export async function appEtherscanAccountTransactions(params?: BlockPagination): Promise<
-  | {
-      address: string
-      transactions: Array<any>
-    }
-  | undefined
-  | void
-> {
-  try {
-    const { data } = await axios.get('/api/etherscan/account/transactions', {
-      params: params,
-    })
-    return data
-  } catch (error: any) {
-    throw new Error(`Unexpected Error`)
   }
 }

--- a/integrations/etherscan/hooks/use-etherscan-account-transactions.ts
+++ b/integrations/etherscan/hooks/use-etherscan-account-transactions.ts
@@ -1,6 +1,6 @@
 import { useQuery } from 'wagmi'
 
-import { appEtherscanAccountTransactions } from '@/integrations/etherscan/actions/etherscan-account-transactions'
+import { appEtherscanAccountTransactions } from '@/integrations/etherscan/actions/etherscan-account-transactions/client'
 
 export const useEtherscanAccountTransactions = (params?: BlockPagination, queryKey?: any) => {
   return useQuery(['accountTransactions', params, queryKey], () => appEtherscanAccountTransactions(params), {


### PR DESCRIPTION
After adding the t3-env package to TurboETH, the following pages broke due to import of private env variables from Etherscan and Disco into client components:
- [Rainbowkit](https://www.turboeth.xyz/integration/rainbowkit)
- [Etherscan](https://www.turboeth.xyz/integration/etherscan)
-  [Disco](https://www.turboeth.xyz/integration/disco)
- [Transactions Dashboard](https://www.turboeth.xyz/dashboard/transactions)

This PR splits the affected functions into client and server imported files, fixing the breaking issue.