### PR TITLE
Fix: show select token form even if no token address storage

### DIFF
--- a/app/(general)/integration/erc721/page.tsx
+++ b/app/(general)/integration/erc721/page.tsx
@@ -51,9 +51,9 @@ export default function PageIntegration() {
           <BranchIsWalletConnected>
             <div className="flex w-full max-w-screen-lg flex-col gap-y-8">
               <ERC721Deploy />
+              <Erc721SetTokenStorage />
               {token && (
                 <>
-                  <Erc721SetTokenStorage />
                   <Erc721Read address={token} />
                   <Erc721WriteMint address={token} />
                   <Erc721WriteApprove address={token} />


### PR DESCRIPTION
Show the select contract form even if the user has no token address on localStorage.