### PR TITLE
[main] Chore: add default value to NEXTAUTH_SECRET

### DIFF
--- a/env.mjs
+++ b/env.mjs
@@ -4,7 +4,7 @@ import { z } from 'zod'
 export const env = createEnv({
   server: {
     // Iron session requires a secret of at least 32 characters
-    NEXTAUTH_SECRET: z.string().min(32),
+    NEXTAUTH_SECRET: z.string().min(32).default('complex_password_at_least_32_characters_long'),
     DATABASE_URL: z.string().url().optional(),
     // Comma separated list of Ethereum addresses, accepts optinal whitespace after comma
     APP_ADMINS: z


### PR DESCRIPTION
This PR introduces a default value for the `NEXTAUTH_SECRET` environment variable. Previously, this was the sole required environment variable to initiate the project and its absence would trigger a runtime check failure via t3-env. Now, with this modification, users can launch the project without needing to perform any prior configurations.