### PR TITLE
[integrations] Feat: add missing integrations to homepage

### DIFF
--- a/app/(general)/page.tsx
+++ b/app/(general)/page.tsx
@@ -238,6 +238,21 @@ const features = [
     ),
   },
   {
+    title: turboIntegrations.sessionKeys.name,
+    description: turboIntegrations.sessionKeys.description,
+    href: turboIntegrations.sessionKeys.href,
+    demo: (
+      <div className="flex items-center justify-center space-x-20">
+        <IsLightTheme>
+          <Image alt="Session keys logo" height={100} src={turboIntegrations.sessionKeys.imgDark} width={100} />
+        </IsLightTheme>
+        <IsDarkTheme>
+          <Image alt="Session keys logo" height={100} src={turboIntegrations.sessionKeys.imgLight} width={100} />
+        </IsDarkTheme>
+      </div>
+    ),
+  },
+  {
     title: turboIntegrations.litProtocol.name,
     description: turboIntegrations.litProtocol.description,
     href: turboIntegrations.litProtocol.href,
@@ -278,6 +293,21 @@ const features = [
         </IsLightTheme>
         <IsDarkTheme>
           <Image alt="PoolTogether logo" height={100} src={turboIntegrations.pooltogether_v4.imgLight} width={100} />
+        </IsDarkTheme>
+      </div>
+    ),
+  },
+  {
+    title: turboIntegrations.starter.name,
+    description: turboIntegrations.starter.description,
+    href: turboIntegrations.starter.href,
+    demo: (
+      <div className="flex items-center justify-center space-x-20">
+        <IsLightTheme>
+          <Image alt="Starter logo" height={100} src={turboIntegrations.starter.imgDark} width={100} />
+        </IsLightTheme>
+        <IsDarkTheme>
+          <Image alt="Starter logo" height={100} src={turboIntegrations.starter.imgLight} width={100} />
         </IsDarkTheme>
       </div>
     ),

--- a/data/turbo-integrations.ts
+++ b/data/turbo-integrations.ts
@@ -44,7 +44,7 @@ export const turboIntegrations = {
     href: '/integration/session-keys',
     // TODO: Update url to the session keys section of Turbo ETH docs once it's finished
     url: 'https://viem.sh/',
-    description: 'Session Keys are a simple way to use short lived private keys to sign transactions and give temporary smart contract permissions.',
+    description: 'Short-lived private keys enable transaction signing and the granting of temporary smart contract permissions.',
     imgLight: '/integrations/session-keys.png',
     imgDark: '/integrations/session-keys.png',
   },


### PR DESCRIPTION
This PR adds cards for Session Keys and Starter integration cards to the main page. It also shortens the description of session keys integration to fit better in the homepage card.