### PR TITLE
Chore: turn site_url env public

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,9 @@ NEXT_PUBLIC_INFURA_API_KEY=
 # Enables the use of production networks in the development environment
 NEXT_PUBLIC_PROD_NETWORKS_DEV=false 
 
+# Website URL
+NEXT_PUBLIC_SITE_URL=
+
 # -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 # Private Variables
 # -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
@@ -25,9 +28,6 @@ DATABASE_URL=
 # Users to be added as admins. Separate with commas. Can access the application database
 # Example: "0x123,0x456"
 APP_ADMINS=""
-
-# Website URL
-SITE_URL=
 
 # Disco: https://docs.disco.xyz
 # Request API access at https://discoxyz.typeform.com/requestapi

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,7 +12,7 @@ import { siteConfig } from '@/config/site'
 import { env } from '@/env.mjs'
 import { cn } from '@/lib/utils'
 
-const url = env.SITE_URL || 'http://localhost:3000'
+const url = env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
 
 export const metadata = {
   metadataBase: new URL(url),

--- a/components/ui/social/og-image-integrations.tsx
+++ b/components/ui/social/og-image-integrations.tsx
@@ -12,7 +12,7 @@ export const size = {
 
 export const contentType = 'image/png'
 
-const url = env.SITE_URL || 'http://localhost:3000'
+const url = env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
 
 export function IntegrationOgImage(integration: keyof typeof turboIntegrations) {
   const integrationData = turboIntegrations[integration]

--- a/env.mjs
+++ b/env.mjs
@@ -11,7 +11,6 @@ export const env = createEnv({
       .string()
       .regex(/^(0x[a-fA-F0-9]{40}( *, *0x[a-fA-F0-9]{40})* *)*$/)
       .optional(),
-    SITE_URL: z.string().url().optional(),
     DISCO_API_KEY: z.string().min(1).optional(),
     OPENAI_API_KEY: z.string().min(1).optional(),
     ETHERSCAN_API_KEY: z.string().min(1).optional(),
@@ -24,12 +23,12 @@ export const env = createEnv({
     NEXT_PUBLIC_PROD_NETWORKS_DEV: z.enum(['true', 'false']).default('false'),
     NEXT_PUBLIC_ALCHEMY_API_KEY: z.string().min(1).optional(),
     NEXT_PUBLIC_INFURA_API_KEY: z.string().min(1).optional(),
+    NEXT_PUBLIC_SITE_URL: z.string().url().optional(),
   },
   runtimeEnv: {
     NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET,
     DATABASE_URL: process.env.DATABASE_URL,
     APP_ADMINS: process.env.APP_ADMINS,
-    SITE_URL: process.env.SITE_URL,
     DISCO_API_KEY: process.env.DISCO_API_KEY,
     OPENAI_API_KEY: process.env.OPENAI_API_KEY,
     NEXT_PUBLIC_PROD_NETWORKS_DEV: process.env.NEXT_PUBLIC_PROD_NETWORKS_DEV,
@@ -40,5 +39,6 @@ export const env = createEnv({
     NEXT_PUBLIC_USE_PUBLIC_PROVIDER: process.env.NEXT_PUBLIC_USE_PUBLIC_PROVIDER,
     NEXT_PUBLIC_ALCHEMY_API_KEY: process.env.NEXT_PUBLIC_ALCHEMY_API_KEY,
     NEXT_PUBLIC_INFURA_API_KEY: process.env.NEXT_PUBLIC_INFURA_API_KEY,
+    NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
   },
 })

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -17,7 +17,7 @@ export function formatDate(input: string | number): string {
 }
 
 export function absoluteUrl(path: string) {
-  return `${env.SITE_URL || 'http://localhost:3000'}${path}`
+  return `${env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'}${path}`
 }
 
 export function trimFormattedBalance(balance: string | undefined, decimals = 4) {


### PR DESCRIPTION
This PR moves the `SITE_URL` environment variable from a private scope to a public one, now exposed to the client side as `NEXT_PUBLIC_SITE_URL`. This change is due to the upcoming [Livepeer integration's ](https://github.com/turbo-eth/template-web3-app/pull/113)requirement to use it on the client side. Since it doesn't carry any sensitive information, sharing it on the client side is not a concern.