### PR TITLE
[integrations] Fix: remove nested button from link and non existing css style

### DIFF
--- a/app/(general)/integration/connext/layout.tsx
+++ b/app/(general)/integration/connext/layout.tsx
@@ -31,7 +31,7 @@ export default function ConnextLayout({ children }: { children: ReactNode }) {
               }}>
               <Image alt="Connext Icon" className="mx-auto mb-5" height={100} src={turboIntegrations.connext.imgDark} width={100} />
               <motion.h1
-                className="text-gradient-pooltogether pb-5 text-center text-2xl font-bold tracking-[-0.02em] drop-shadow-sm md:text-8xl md:leading-[6rem]"
+                className="text-gradient-sand pb-5 text-center text-2xl font-bold tracking-[-0.02em] drop-shadow-sm md:text-8xl md:leading-[6rem]"
                 variants={FADE_DOWN_ANIMATION_VARIANTS}>
                 Connext
               </motion.h1>
@@ -39,8 +39,8 @@ export default function ConnextLayout({ children }: { children: ReactNode }) {
                 <Balancer className="text-xl font-semibold">Bridge assets directly from your app</Balancer>
               </motion.p>
               <motion.div className="my-4 text-xl" variants={FADE_DOWN_ANIMATION_VARIANTS}>
-                <LinkComponent isExternal href={turboIntegrations.connext.url}>
-                  <button className="btn btn-primary">Documentation</button>
+                <LinkComponent isExternal className="btn btn-primary" href={turboIntegrations.connext.url}>
+                  Documentation
                 </LinkComponent>
               </motion.div>
             </motion.div>

--- a/app/(general)/integration/disco/page.tsx
+++ b/app/(general)/integration/disco/page.tsx
@@ -52,8 +52,8 @@ export default function PageIntegration() {
             <Balancer>{turboIntegrations.disco.description}</Balancer>
           </motion.p>
           <motion.div className="my-4 text-xl" variants={FADE_DOWN_ANIMATION_VARIANTS}>
-            <LinkComponent isExternal href={turboIntegrations.disco.url}>
-              <button className="btn btn-primary">Documentation</button>
+            <LinkComponent isExternal className="btn btn-primary" href={turboIntegrations.disco.url}>
+              Documentation
             </LinkComponent>
           </motion.div>
         </motion.div>

--- a/app/(general)/integration/erc20/page.tsx
+++ b/app/(general)/integration/erc20/page.tsx
@@ -43,8 +43,8 @@ export default function PageIntegration() {
             <Balancer>{turboIntegrations.erc20.description}</Balancer>
           </motion.p>
           <motion.div className="my-4 text-xl" variants={FADE_DOWN_ANIMATION_VARIANTS}>
-            <LinkComponent isExternal href={turboIntegrations.erc20.url}>
-              <button className="btn btn-primary">Documentation</button>
+            <LinkComponent isExternal className="btn btn-primary" href={turboIntegrations.erc20.url}>
+              Documentation
             </LinkComponent>
           </motion.div>
         </motion.div>

--- a/app/(general)/integration/erc721/page.tsx
+++ b/app/(general)/integration/erc721/page.tsx
@@ -41,8 +41,8 @@ export default function PageIntegration() {
             <Balancer>{turboIntegrations.erc721.description}</Balancer>
           </motion.p>
           <motion.div className="my-4 text-xl" variants={FADE_DOWN_ANIMATION_VARIANTS}>
-            <LinkComponent isExternal href={turboIntegrations.erc721.url}>
-              <button className="btn btn-primary">Documentation</button>
+            <LinkComponent isExternal className="btn btn-primary" href={turboIntegrations.erc721.url}>
+              Documentation
             </LinkComponent>
           </motion.div>
         </motion.div>

--- a/app/(general)/integration/etherscan/page.tsx
+++ b/app/(general)/integration/etherscan/page.tsx
@@ -55,8 +55,8 @@ export default function PageIntegration() {
             <Balancer>{turboIntegrations.etherscan.description}</Balancer>
           </motion.p>
           <motion.div className="my-4 text-xl" variants={FADE_DOWN_ANIMATION_VARIANTS}>
-            <LinkComponent isExternal href={turboIntegrations.etherscan.url}>
-              <button className="btn btn-primary">Documentation</button>
+            <LinkComponent isExternal className="btn btn-primary" href={turboIntegrations.etherscan.url}>
+              Documentation
             </LinkComponent>
           </motion.div>
         </motion.div>

--- a/app/(general)/integration/lit-protocol/layout.tsx
+++ b/app/(general)/integration/lit-protocol/layout.tsx
@@ -45,16 +45,16 @@ export default function LayoutIntegration({ children }: LayoutIntegrationProps) 
             <Balancer>{turboIntegrations.litProtocol.description}</Balancer>
           </motion.p>
           <motion.div className="my-4 text-xl" variants={FADE_DOWN_ANIMATION_VARIANTS}>
-            <LinkComponent isExternal href={turboIntegrations.litProtocol.url}>
-              <button className="btn btn-primary">Documentation</button>
+            <LinkComponent isExternal className="btn btn-primary" href={turboIntegrations.litProtocol.url}>
+              Documentation
             </LinkComponent>
           </motion.div>
           <motion.div className="mt-8 flex justify-center gap-14 text-2xl" variants={FADE_DOWN_ANIMATION_VARIANTS}>
-            <LinkComponent href={sharePath}>
-              <button className={cn('btn hover:opacity-75', pathname === unsealPath && 'opacity-50')}>Share</button>
+            <LinkComponent className={cn('btn hover:opacity-75', pathname === unsealPath && 'opacity-50')} href={sharePath}>
+              Share
             </LinkComponent>
-            <LinkComponent href={unsealPath}>
-              <button className={cn('btn hover:opacity-75', pathname === sharePath && 'opacity-50')}>Unseal</button>
+            <LinkComponent className={cn('btn hover:opacity-75', pathname === sharePath && 'opacity-50')} href={unsealPath}>
+              Unseal
             </LinkComponent>
           </motion.div>
         </motion.div>

--- a/app/(general)/integration/openai/page.tsx
+++ b/app/(general)/integration/openai/page.tsx
@@ -35,8 +35,8 @@ export default function PageIntegration() {
             <Balancer>{turboIntegrations.openai.description}</Balancer>
           </motion.p>
           <motion.div className="my-4 text-xl" variants={FADE_DOWN_ANIMATION_VARIANTS}>
-            <LinkComponent isExternal href={turboIntegrations.openai.url}>
-              <button className="btn btn-primary">Documentation</button>
+            <LinkComponent isExternal className="btn btn-primary" href={turboIntegrations.openai.url}>
+              Documentation
             </LinkComponent>
           </motion.div>
         </motion.div>

--- a/app/(general)/integration/pooltogether-v4/layout.tsx
+++ b/app/(general)/integration/pooltogether-v4/layout.tsx
@@ -53,16 +53,16 @@ export default function PoolTogetherLayout({ children }: { children: ReactNode }
             <Balancer>{integrationData.description}</Balancer>
           </motion.p>
           <motion.div className="my-4 text-xl" variants={FADE_DOWN_ANIMATION_VARIANTS}>
-            <LinkComponent href={integrationData.url}>
-              <button className="btn btn-primary">Documentation</button>
+            <LinkComponent className="btn btn-primary" href={integrationData.url}>
+              Documentation
             </LinkComponent>
           </motion.div>
           <motion.div className="mt-8 flex justify-center gap-4 text-2xl sm:gap-6 md:gap-10 lg:gap-14" variants={FADE_DOWN_ANIMATION_VARIANTS}>
-            <LinkComponent href={depositPath}>
-              <button className={cn('btn hover:opacity-75', pathname === depositPath && 'opacity-50')}>Deposit</button>
+            <LinkComponent className={cn('btn hover:opacity-75', pathname === depositPath && 'opacity-50')} href={depositPath}>
+              Deposit
             </LinkComponent>
-            <LinkComponent href={withdrawPath}>
-              <button className={cn('btn hover:opacity-75', pathname === withdrawPath && 'opacity-50')}>Withdraw</button>
+            <LinkComponent className={cn('btn hover:opacity-75', pathname === withdrawPath && 'opacity-50')} href={withdrawPath}>
+              Withdraw
             </LinkComponent>
           </motion.div>
         </motion.div>

--- a/app/(general)/integration/session-keys/page.tsx
+++ b/app/(general)/integration/session-keys/page.tsx
@@ -42,8 +42,8 @@ export default function PageIntegration() {
             <Balancer>{turboIntegrations.sessionKeys.description}</Balancer>
           </motion.p>
           <motion.div className="my-4 text-xl" variants={FADE_DOWN_ANIMATION_VARIANTS}>
-            <LinkComponent isExternal href={turboIntegrations.sessionKeys.url}>
-              <button className="btn btn-primary">Documentation</button>
+            <LinkComponent isExternal className="btn btn-primary" href={turboIntegrations.sessionKeys.url}>
+              Documentation
             </LinkComponent>
           </motion.div>
         </motion.div>

--- a/app/(general)/integration/sign-in-with-ethereum/page.tsx
+++ b/app/(general)/integration/sign-in-with-ethereum/page.tsx
@@ -48,8 +48,8 @@ export default function PageIntegration() {
           <Balancer>{turboIntegrations.siwe.description}</Balancer>
         </motion.p>
         <motion.div className="my-4 text-xl" variants={FADE_DOWN_ANIMATION_VARIANTS}>
-          <LinkComponent isExternal href={turboIntegrations.siwe.url}>
-            <button className="btn btn-primary">Documentation</button>
+          <LinkComponent isExternal className="btn btn-primary" href={turboIntegrations.siwe.url}>
+            Documentation
           </LinkComponent>
         </motion.div>
       </motion.div>

--- a/app/(general)/integration/starter/layout.tsx
+++ b/app/(general)/integration/starter/layout.tsx
@@ -46,8 +46,8 @@ export default function LayoutIntegration({ children }: { children: ReactNode })
             <Balancer>{integrationData.description}</Balancer>
           </motion.p>
           <motion.div className="my-4 text-xl" variants={FADE_DOWN_ANIMATION_VARIANTS}>
-            <LinkComponent href={integrationData.url}>
-              <button className="btn btn-primary">Documentation</button>
+            <LinkComponent className="btn btn-primary" href={integrationData.url}>
+              Documentation
             </LinkComponent>
           </motion.div>
         </motion.div>

--- a/app/(general)/layout.tsx
+++ b/app/(general)/layout.tsx
@@ -9,7 +9,7 @@ import { Toaster } from '@/components/ui/toaster'
 export default function GeneralLayout({ children }: { children: ReactNode }) {
   return (
     <>
-      <div className="bg-gradient-dark lg:pb-12' flex min-h-[100vh] flex-col pb-10">
+      <div className="flex min-h-[100vh] flex-col pb-10 lg:pb-12">
         <Header />
         <main className="flex-center my-32 flex flex-1 flex-col md:px-10 lg:py-20">{children}</main>
         <div className="fixed bottom-6 left-6">

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -16,7 +16,7 @@ import { siteConfig } from '@/config/site'
 
 export default function AdminLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="bg-gradient-dark h-screen lg:grid lg:grid-cols-12">
+    <div className="h-screen lg:grid lg:grid-cols-12">
       <div className="col-span-12 flex flex-col bg-slate-50 shadow-md dark:bg-slate-800 lg:col-span-2 lg:pb-8">
         <IsMobile>
           <div className="flex p-4">

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -18,7 +18,7 @@ import { siteConfig } from '@/config/site'
 export default function DashboardLayout({ children }: { children: ReactNode }) {
   return (
     <>
-      <div className="bg-gradient-dark flex h-screen flex-col lg:grid lg:grid-cols-12">
+      <div className="flex h-screen flex-col lg:grid lg:grid-cols-12">
         <div className="col-span-12 flex flex-col bg-slate-50 shadow-md dark:bg-slate-800 lg:col-span-2 lg:pb-8">
           <IsMobile>
             <div className="flex p-4">

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -61,10 +61,8 @@ export function Header({ className, ...props }: HTMLAttributes<HTMLElement>) {
         </div>
         <div className="flex items-center gap-4">
           <BranchButtonLoginOrAccount classNameButtonLogin="menu-item colormode" classNameButtonLogout="menu-item" />
-          <LinkComponent className="flex items-center" href="/dashboard">
-            <button className="btn btn-pill bg-gradient-button hover:scale-105 hover:shadow-lg">
-              <span className="px-2">Dashboard</span>
-            </button>
+          <LinkComponent className="btn btn-pill bg-gradient-button px-2 hover:scale-105 hover:shadow-lg" href="/dashboard">
+            Dashboard
           </LinkComponent>
           <ThemeToggle />
         </div>

--- a/components/shared/card.tsx
+++ b/components/shared/card.tsx
@@ -52,8 +52,8 @@ export default function Card({
           </Balancer>
         </div>
         {!href ? null : (
-          <LinkComponent href={href}>
-            <button className="btn btn-light my-4">Demo</button>
+          <LinkComponent className="btn btn-light my-4" href={href}>
+            Demo
           </LinkComponent>
         )}
       </div>


### PR DESCRIPTION
This PR remove:
- invocation of non existing css style class such as `text-gradient-pooltogether` and `bg-gradient-dark`
- use of nested `<button>` inside `<LinkComponent>`