### PR TITLE
Fix: add minor fixes to the Livepeer integration

### DIFF
--- a/app/(general)/integration/livepeer/livestream/page.tsx
+++ b/app/(general)/integration/livepeer/livestream/page.tsx
@@ -16,12 +16,12 @@ export default function PageIntegration() {
       {!isLivepeerApiKeySet && <FormLivepeerApiKey />}
       <LinkComponent href={newStreamObsPath}>
         <button className="btn btn-emerald mt-4 w-full" disabled={!isLivepeerApiKeySet}>
-          Create a new OBS livestream
+          Go live from OBS
         </button>
       </LinkComponent>
       <LinkComponent href={newStreamBrowserPath}>
         <button className="btn btn-emerald mt-4 w-full" disabled={!isLivepeerApiKeySet}>
-          Create a new Browser livestream
+          Go live from your browser
         </button>
       </LinkComponent>
       <LinkComponent href={watchStreamPath}>

--- a/app/(general)/integration/livepeer/vod/[playbackId]/page.tsx
+++ b/app/(general)/integration/livepeer/vod/[playbackId]/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useAsset } from '@livepeer/react'
+import { usePlaybackInfo } from '@livepeer/react'
 
 import { LinkComponent } from '@/components/shared/link-component'
 import { ButtonShare } from '@/integrations/livepeer/components/button-share'
@@ -12,14 +12,13 @@ import { useIsLivepeerApiKeySet } from '@/integrations/livepeer/hooks/use-livepe
 const watchVideoPath = '/integration/livepeer/vod/watch/'
 const videoPath = '/integration/livepeer/vod/'
 
-export default function Page({ params }: { params: { assetId: string } }) {
+export default function Page({ params }: { params: { playbackId: string } }) {
+  const { playbackId } = params
   const isLivepeerApiKeySet = useIsLivepeerApiKeySet()
 
-  const SHARE_HREF = videoPath + params.assetId
+  const SHARE_HREF = videoPath + playbackId
 
-  const { data: asset, error } = useAsset({
-    assetId: params.assetId,
-  })
+  const { data: playbackInfo, error } = usePlaybackInfo(playbackId)
 
   if (error) {
     return (
@@ -44,7 +43,7 @@ export default function Page({ params }: { params: { assetId: string } }) {
     )
   }
 
-  if (!asset || !asset.playbackId)
+  if (!playbackInfo)
     return (
       <div className="flex w-full items-center justify-center py-20">
         <Spinner />
@@ -53,7 +52,7 @@ export default function Page({ params }: { params: { assetId: string } }) {
 
   return (
     <>
-      <PlayerComponent containerBorderRadius="16px" playbackId={asset.playbackId} title={asset.name} type={PlayerType.FILE} />
+      <PlayerComponent containerBorderRadius="16px" playbackId={playbackId} title="Video On Demand" type={PlayerType.FILE} />
       <ButtonShare href={SHARE_HREF} PlayerType={PlayerType.FILE} />
     </>
   )

--- a/data/turbo-integrations.ts
+++ b/data/turbo-integrations.ts
@@ -75,8 +75,8 @@ export const turboIntegrations = {
   livepeer: {
     name: 'Livepeer',
     href: '/integration/livepeer',
-    url: 'https://livepeer.org/',
-    description: 'Livepeer is a decentralized video streaming network.',
+    url: 'https://docs.livepeer.org/',
+    description: "Livepeer is the world's open video infrastructure.",
     imgLight: '/integrations/livepeer.svg',
     imgDark: '/integrations/livepeer.svg',
   },

--- a/integrations/livepeer/components/form-livepeer-asset.tsx
+++ b/integrations/livepeer/components/form-livepeer-asset.tsx
@@ -6,27 +6,27 @@ import { useRouter } from 'next/navigation'
 import { useForm } from 'react-hook-form'
 
 interface livepeerForm {
-  assetId: string
+  playbackId: string
 }
 
 export function FormLivepeerAsset() {
   const route = useRouter()
   const { register, handleSubmit } = useForm<livepeerForm>()
   const [isLoading, setIsLoading] = useState<boolean>(false)
-  const [assetId, setAssetId] = useState<string>('')
+  const [playbackId, setPlaybackId] = useState<string>('')
 
   function onSubmit(FieldValues: livepeerForm) {
     setIsLoading(true)
-    if (FieldValues.assetId !== '') {
-      route.push(`/integration/livepeer/vod/${FieldValues.assetId}`)
+    if (FieldValues.playbackId !== '') {
+      route.push(`/integration/livepeer/vod/${FieldValues.playbackId}`)
     }
   }
   return (
     <div className="card w-full">
       <form onSubmit={handleSubmit(onSubmit)}>
-        <label>Asset ID</label>
-        <input required className="input mt-4" {...register('assetId')} value={assetId} onChange={(e) => setAssetId(e.target.value)} />
-        <button className="btn btn-emerald mt-4 w-full" disabled={!assetId || isLoading} type="submit">
+        <label>Playback ID</label>
+        <input required className="input mt-4" {...register('playbackId')} value={playbackId} onChange={(e) => setPlaybackId(e.target.value)} />
+        <button className="btn btn-emerald mt-4 w-full" disabled={!playbackId || isLoading} type="submit">
           {isLoading ? 'Loading...' : 'Submit'}
         </button>
       </form>

--- a/integrations/livepeer/components/form-livepeer-asset.tsx
+++ b/integrations/livepeer/components/form-livepeer-asset.tsx
@@ -10,10 +10,10 @@ interface livepeerForm {
 }
 
 export function FormLivepeerAsset() {
-  const route = useRouter()
-  const { register, handleSubmit } = useForm<livepeerForm>()
   const [isLoading, setIsLoading] = useState<boolean>(false)
-  const [playbackId, setPlaybackId] = useState<string>('')
+  const route = useRouter()
+  const { register, handleSubmit, watch } = useForm<livepeerForm>()
+  const playbackId = watch('playbackId')
 
   function onSubmit(FieldValues: livepeerForm) {
     setIsLoading(true)
@@ -25,7 +25,7 @@ export function FormLivepeerAsset() {
     <div className="card w-full">
       <form onSubmit={handleSubmit(onSubmit)}>
         <label>Playback ID</label>
-        <input required className="input mt-4" {...register('playbackId')} value={playbackId} onChange={(e) => setPlaybackId(e.target.value)} />
+        <input required className="input mt-4" {...register('playbackId')} />
         <button className="btn btn-emerald mt-4 w-full" disabled={!playbackId || isLoading} type="submit">
           {isLoading ? 'Loading...' : 'Submit'}
         </button>

--- a/integrations/livepeer/components/player.tsx
+++ b/integrations/livepeer/components/player.tsx
@@ -45,6 +45,7 @@ export function PlayerComponent({
 
   return (
     <Player
+      lowLatency
       priority
       showPipButton
       objectFit="cover"

--- a/integrations/livepeer/components/upload-file.tsx
+++ b/integrations/livepeer/components/upload-file.tsx
@@ -70,8 +70,8 @@ export function UploadFile() {
     [progress]
   )
 
-  if (asset?.[0]) {
-    route.push(`/integration/livepeer/vod/${asset[0].id}`)
+  if (asset?.[0] && asset[0].playbackId) {
+    route.push(`/integration/livepeer/vod/${asset[0].playbackId}`)
   }
 
   return (


### PR DESCRIPTION
This PR adds the following minor fixes to the Livepeer Integration based on feedback from the Livepeer team:
- Update Docs link to https://docs.livepeer.org/
- Add `lowLatency` parameter to the `PlayerComponent` in order to reduce latency from ~10 seconds to ~1 second.
- Expose `playbackId` for the vod page rather than `assetId` as `assetId` is not meant to be exposed publicly
- Copy fixes on the integration description 
Livepeer is a decentralized video streaming network. -> Livepeer is the world's open video infrastructure.

> previous copy
![image](https://github.com/turbo-eth/template-web3-app/assets/18421017/09def86f-284f-4a16-85d9-e235e5055964)

> new copy
![image](https://github.com/turbo-eth/template-web3-app/assets/18421017/6ce41bb7-7705-4267-805e-8ab8401ac624)


- Copy fixes on the livestream page
Create a new Browser livestream` -> `Go live from your browser`
`Create a new OBS livestream` -> `Go live from OBS`

> previous copy
![image](https://github.com/turbo-eth/template-web3-app/assets/18421017/f5755729-7e4a-431b-9d07-3ee1560acdde)

> new copy
![image](https://github.com/turbo-eth/template-web3-app/assets/18421017/ef3d0ab9-548c-499e-bb45-35f354c3b756)
