### PR TITLE
Fix: text align integration description in OG image

### DIFF
--- a/components/ui/social/og-image-integrations.tsx
+++ b/components/ui/social/og-image-integrations.tsx
@@ -56,6 +56,7 @@ export function IntegrationOgImage(integration: keyof typeof turboIntegrations) 
               fontSize: '22px',
               fontFamily: 'SF Pro',
               maxWidth: '800px',
+              textAlign: 'center',
               background: 'linear-gradient(to bottom right, #000000 21.66%, #78716c 86.47%)',
               backgroundClip: 'text',
               color: 'transparent',


### PR DESCRIPTION
This PR center aligns integration descriptions in the OG images

current OG image:
![image](https://github.com/turbo-eth/template-web3-app/assets/18421017/d5b71cbd-d16c-4e65-9095-f57011c0e8aa)

new OG image:
![image](https://github.com/turbo-eth/template-web3-app/assets/18421017/1441b9e9-e3b5-4889-bd06-04177225b6f1)