### PR TITLE
fix: npm prepare is error in windows10

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "next lint --fix",
     "prettier": "prettier './src' --write",
-    "prepare": "husky install ; prisma generate ; wagmi generate"
+    "prepare": "prisma generate ; wagmi generate && husky install"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
when run `pnpm i` in windows10, the `husky install` will cause the `npm prepare` to fail to execute.
change the `"prepare": "husky install ; prisma generate ; wagmi generate"` to
`"prepare": "prisma generate ; wagmi generate&&husky install "` can execute success